### PR TITLE
Sprite generator v3: cute pixel art overhaul

### DIFF
--- a/tools/sprite-generator.html
+++ b/tools/sprite-generator.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>スプライトジェネレーター</title>
+<title>スプライトジェネレーター v3</title>
 <style>
   :root { --bg:#1a1a2a; --panel:#0f1424; --accent:#F5A623; --text:#eee; --muted:#777; }
   *{box-sizing:border-box}
@@ -16,27 +16,28 @@
   button{background:var(--accent);color:#000;border:none;padding:8px 16px;border-radius:6px;cursor:pointer;font-weight:bold}
   button.secondary{background:#555;color:#eee}
   input, select{background:#0b0f1c;color:#eee;border:1px solid #333;padding:6px 8px;border-radius:6px}
-  canvas{image-rendering:pixelated;background:#0b0f1c;border:1px solid #222;border-radius:6px}
+  canvas{image-rendering:pixelated;border:1px solid #222;border-radius:6px}
   .small{color:var(--muted);font-size:12px}
-  .label-grid{display:grid;gap:6px;margin-top:10px}
   .label{font-size:12px;color:#ddd;text-align:center}
   details{background:#0b0f1c;border:1px solid #222;border-radius:8px;padding:10px}
   summary{cursor:pointer;color:#f8d36a}
   .preview-grid{display:grid;grid-template-columns:repeat(6, 1fr);gap:6px;margin-top:10px}
   .preview-item{display:flex;flex-direction:column;align-items:center;gap:4px}
   .info{color:#aaa;font-size:12px}
+  .checker{background-image:linear-gradient(45deg,#333 25%,transparent 25%),linear-gradient(-45deg,#333 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#333 75%),linear-gradient(-45deg,transparent 75%,#333 75%);
+    background-size:16px 16px;background-position:0 0,0 8px,8px -8px,-8px 0px;}
 </style>
 </head>
 <body>
 <div class="wrap">
-  <h1>スプライトジェネレーター</h1>
+  <h1>スプライトジェネレーター v3 – かわいいドットキャラ</h1>
 
   <div class="panel">
     <details>
       <summary>使い方</summary>
       <div class="small" style="margin-top:8px;">
         <div>このツールは「ミプリンの冒険」向けのスプライトシートをCanvas 2Dだけで生成します。</div>
-        <div>Seedを変更してRegenerateすると、細部の配置やシェーディングが変化します。</div>
+        <div>Seedを変更してRegenerateすると、ディテールや配置が変化します。</div>
         <div>PNG/JSONをダウンロードし、`assets/sprites/` に配置してSpriteManagerのフォーマットに合わせて使用できます。</div>
         <div>ZIPで一括ダウンロードも可能です。</div>
       </div>
@@ -50,7 +51,7 @@
       <button id="regen">Regenerate</button>
       <button id="downloadAll" class="secondary">Download All (ZIP)</button>
     </div>
-    <div class="small">64色パレットをベースに、アウトライン＋3段階シェーディング＋ディザで生成</div>
+    <div class="small">64色パレット + パステル強め / アウトラインは有彩色暗色 / 3fpsプレビュー</div>
   </div>
 
   <div class="panel">
@@ -63,9 +64,8 @@
       <button id="dlEnemyJson" class="secondary">Download JSON</button>
       <label class="small">Zoom</label>
       <input id="enemyZoom" type="range" min="1" max="8" value="4" />
-      <button id="enemyPlay" class="secondary">Preview Animation</button>
     </div>
-    <canvas id="enemyCanvas" width="96" height="288"></canvas>
+    <canvas id="enemyCanvas" class="checker" width="96" height="288"></canvas>
     <div id="enemyPreview" class="preview-grid"></div>
   </div>
 
@@ -79,9 +79,8 @@
       <button id="dlNpcJson" class="secondary">Download JSON</button>
       <label class="small">Zoom</label>
       <input id="npcZoom" type="range" min="1" max="8" value="4" />
-      <button id="npcPlay" class="secondary">Preview Animation</button>
     </div>
-    <canvas id="npcCanvas" width="64" height="256"></canvas>
+    <canvas id="npcCanvas" class="checker" width="64" height="256"></canvas>
     <div id="npcPreview" class="preview-grid"></div>
   </div>
 
@@ -96,7 +95,21 @@
       <label class="small">Zoom</label>
       <input id="bossZoom" type="range" min="1" max="6" value="2" />
     </div>
-    <canvas id="bossCanvas" width="256" height="192"></canvas>
+    <canvas id="bossCanvas" class="checker" width="256" height="192"></canvas>
+  </div>
+
+  <div class="panel">
+    <div class="row" style="justify-content:space-between;">
+      <h2>Player Sprites (32x32, 14 frames)</h2>
+      <div class="info">32x32 / 14 frames / walk4x3 + attack2</div>
+    </div>
+    <div class="row" style="margin:8px 0;">
+      <button id="dlPlayer">Download PNG</button>
+      <button id="dlPlayerJson" class="secondary">Download JSON</button>
+      <label class="small">Zoom</label>
+      <input id="playerZoom" type="range" min="1" max="8" value="4" />
+    </div>
+    <canvas id="playerCanvas" class="checker" width="448" height="32"></canvas>
   </div>
 
   <div class="panel">
@@ -110,8 +123,8 @@
       <label class="small">Zoom</label>
       <input id="tileZoom" type="range" min="1" max="8" value="4" />
     </div>
-    <canvas id="tileCanvas" width="320" height="128"></canvas>
-    <div id="tileLabels" class="label-grid"></div>
+    <canvas id="tileCanvas" class="checker" width="320" height="128"></canvas>
+    <div id="tileLabels" class="preview-grid"></div>
   </div>
 </div>
 
@@ -119,20 +132,18 @@
 <script>
 (() => {
   const palette = {
-    warm: ['#f5f2e8','#f8d36a','#f5a623','#e67e22','#d35400','#c0392b','#8b5a2b','#6b3f1e'],
-    cool: ['#85c1e9','#5dade2','#3498db','#2980b9','#1abc9c','#16a085','#48c9b0','#7fb3d5'],
-    nature: ['#2ecc71','#27ae60','#1e8449','#145a32','#4a8c2a','#3d7a22','#2d5a1e','#7dcea0'],
-    dark: ['#0b0f1c','#1a1a2a','#2b2f44','#3b3f5c','#4f4c6a','#6c2eb9','#4a235a','#11111a'],
-    earth: ['#c4a035','#b7950b','#8b7355','#6b5b3a','#7f8c8d','#708090','#a0a0a0','#5d4037'],
-    accent: ['#e74c3c','#ff5a5f','#ff7675','#f1c40f','#ffffff','#f5f2e8','#f8f8ff','#ffb3c1'],
-    metallic: ['#d1d8e0','#bdc3c7','#95a5a6','#f1c40f','#f39c12','#f7dc6f','#a9cce3','#9b59b6'],
-    pastel: ['#f9e79f','#d7bde2','#aed6f1','#d4efdf','#fadbd8','#fcf3cf','#d6eaf8','#f5cba7']
+    warm: ['#fff1d6','#fbd18a','#f5a623','#f29f68','#e07b39','#c96a2a','#a85b2a','#7a4a2a'],
+    cool: ['#e8f6ff','#bfe4ff','#85c1e9','#5dade2','#3498db','#2980b9','#4ad1c8','#7ef0ff'],
+    nature: ['#d7f5d0','#9ee6a1','#6acb6e','#2ecc71','#27ae60','#1e8449','#145a32','#2d5a1e'],
+    dark: ['#1a1a2a','#2a2a4a','#3b3f5c','#4f4c6a','#5b6d7a','#3a2a4a','#4a235a','#11111a'],
+    earth: ['#f2e0c9','#d5b88c','#c4a035','#b7950b','#8b7355','#6b5b3a','#7f8c8d','#708090'],
+    accent: ['#ff6b8a','#ff5a5f','#e74c3c','#f1c40f','#fff8ff','#f5f2e8','#f8f8ff','#ffd1e8'],
+    metallic: ['#e6edf0','#d1d8e0','#bdc3c7','#95a5a6','#f7dc6f','#f1c40f','#a9cce3','#9b59b6'],
+    pastel: ['#f9e79f','#f7c6e3','#d7bde2','#aed6f1','#d4efdf','#fadbd8','#fcf3cf','#f5cba7']
   };
 
-  const enemyTypes = [
-    'poison_mushroom','green_slime','spider','bomb_mushroom','dark_slime','bat','ice_worm','dark_flower','shadow_bee'
-  ];
-  const npcTypes = ['hatch','miel','marche','bee','pore','navi','granpa','sign'];
+  const enemyTypes = ['poison_mushroom','green_slime','spider','bomb_mushroom','dark_slime','bat','ice_worm','dark_flower','shadow_bee'];
+  const npcTypes = ['elder','merchant','healer','guard','child','fairy','cat','mushroom_friend'];
   const bossTypes = ['mushroom_king','ice_beetle','dark_queen'];
   const tileTypes = ['grass','path','wall','water','tree','house','fence','well','flower','bridge','save_point','sign','chest','stump','bush','cave_floor','anchor','seal_wall','exit'];
 
@@ -140,360 +151,366 @@
   const npcCanvas = document.getElementById('npcCanvas');
   const bossCanvas = document.getElementById('bossCanvas');
   const tileCanvas = document.getElementById('tileCanvas');
+  const playerCanvas = document.getElementById('playerCanvas');
   const seedInput = document.getElementById('seed');
 
   const enemyZoom = document.getElementById('enemyZoom');
   const npcZoom = document.getElementById('npcZoom');
   const bossZoom = document.getElementById('bossZoom');
   const tileZoom = document.getElementById('tileZoom');
+  const playerZoom = document.getElementById('playerZoom');
 
   const enemyPreview = document.getElementById('enemyPreview');
   const npcPreview = document.getElementById('npcPreview');
   const tileLabels = document.getElementById('tileLabels');
 
-  let enemyAnim = false;
-  let npcAnim = false;
   let animTick = 0;
   let rafId = null;
 
   document.getElementById('regen').addEventListener('click', generateAll);
 
-  function rng(seed) {
-    let s = seed >>> 0;
-    return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
-  }
-
+  function rng(seed) { let s = seed >>> 0; return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296; }
   function pick(arr, r) { return arr[Math.floor(r() * arr.length)]; }
   function randRange(r, min, max) { return min + (max - min) * r(); }
-  function shade(hex, amt) {
-    const n = parseInt(hex.slice(1), 16);
-    const r = Math.max(0, Math.min(255, (n >> 16) + amt));
-    const g = Math.max(0, Math.min(255, ((n >> 8) & 255) + amt));
-    const b = Math.max(0, Math.min(255, (n & 255) + amt));
-    return '#' + [r,g,b].map(v=>v.toString(16).padStart(2,'0')).join('');
-  }
 
-  function px(ctx, x, y, color) { ctx.fillStyle = color; ctx.fillRect(x, y, 1, 1); }
-  function rect(ctx, x, y, w, h, c) { ctx.fillStyle = c; ctx.fillRect(x, y, w, h); }
-
-  function drawOutlinedCircle(ctx, cx, cy, r, base, outline, highlight) {
-    for (let y=-r-1; y<=r+1; y++) for (let x=-r-1; x<=r+1; x++) {
-      if (x*x + y*y <= (r+1)*(r+1)) px(ctx, cx+x, cy+y, outline);
+  function hexToHsl(hex) {
+    const n = parseInt(hex.slice(1),16);
+    const r = ((n>>16)&255)/255, g = ((n>>8)&255)/255, b = (n&255)/255;
+    const max = Math.max(r,g,b), min = Math.min(r,g,b);
+    let h=0,s=0,l=(max+min)/2;
+    if (max!==min) {
+      const d = max-min;
+      s = l>0.5 ? d/(2-max-min) : d/(max+min);
+      switch(max){case r:h=(g-b)/d+(g<b?6:0);break;case g:h=(b-r)/d+2;break;case b:h=(r-g)/d+4;break;}
+      h/=6;
     }
-    for (let y=-r; y<=r; y++) for (let x=-r; x<=r; x++) {
-      if (x*x + y*y <= r*r) px(ctx, cx+x, cy+y, base);
+    return {h,s,l};
+  }
+  function hslToHex(h,s,l){
+    function hue2rgb(p,q,t){if(t<0)t+=1;if(t>1)t-=1;if(t<1/6)return p+(q-p)*6*t;if(t<1/2)return q;if(t<2/3)return p+(q-p)*(2/3-t)*6;return p;}
+    let r,g,b;
+    if(s===0){r=g=b=l;} else {const q=l<0.5?l*(1+s):l+s-l*s;const p=2*l-q;r=hue2rgb(p,q,h+1/3);g=hue2rgb(p,q,h);b=hue2rgb(p,q,h-1/3);} 
+    return '#' + [r,g,b].map(v=>Math.round(v*255).toString(16).padStart(2,'0')).join('');
+  }
+  function shade(base, amount) {
+    const hsl = hexToHsl(base);
+    const l = Math.max(0, Math.min(1, hsl.l + amount));
+    return hslToHex(hsl.h, hsl.s, l);
+  }
+
+  function drawRoundedRect(ctx, x, y, w, h, r, color) {
+    ctx.fillStyle = color;
+    for (let yy=0; yy<h; yy++) for (let xx=0; xx<w; xx++) {
+      const dx = Math.min(xx, w-1-xx), dy = Math.min(yy, h-1-yy);
+      if (dx<r && dy<r && (dx-r)*(dx-r)+(dy-r)*(dy-r) > r*r) continue;
+      ctx.fillRect(x+xx, y+yy, 1, 1);
     }
-    px(ctx, cx-1, cy-2, highlight);
-    px(ctx, cx, cy-2, highlight);
   }
-
-  function drawShadedRect(ctx, x, y, w, h, base, shadow, highlight, outline) {
-    rect(ctx, x-1, y-1, w+2, h+2, outline);
-    rect(ctx, x, y, w, h, base);
-    rect(ctx, x, y, w, 1, highlight);
-    rect(ctx, x, y+h-1, w, 1, shadow);
+  function drawCircle(ctx, cx, cy, r, color){
+    ctx.fillStyle = color;
+    for (let y=-r;y<=r;y++) for (let x=-r;x<=r;x++) if (x*x+y*y<=r*r) ctx.fillRect(cx+x, cy+y, 1, 1);
   }
-
-  function drawDitheredFill(ctx, x, y, w, h, c1, c2) {
-    for (let j=0;j<h;j++) for (let i=0;i<w;i++) {
-      px(ctx, x+i, y+j, (i+j)%2 ? c1 : c2);
+  function drawEye(ctx, x, y, size, color, highlightDir){
+    drawCircle(ctx, x, y, size, color);
+    const hx = highlightDir==='right'?1:-1;
+    ctx.fillStyle = '#fff'; ctx.fillRect(x-1+hx, y-1, 1, 1);
+  }
+  function drawCheek(ctx, x, y){ drawCircle(ctx, x, y, 1, '#ffb3c1'); }
+  function dither(ctx, x, y, w, h, c1, c2){
+    for (let j=0;j<h;j++) for (let i=0;i<w;i++) ctx.fillStyle=((i+j)%2?c1:c2), ctx.fillRect(x+i,y+j,1,1);
+  }
+  function drawOutline(imageData, color){
+    const d = imageData.data; const w=imageData.width, h=imageData.height;
+    const out = new Uint8ClampedArray(d.length);
+    const col = hexToRgb(color);
+    function idx(x,y){return (y*w+x)*4;}
+    for (let y=1;y<h-1;y++) for (let x=1;x<w-1;x++) {
+      const i = idx(x,y);
+      if (d[i+3]===0) {
+        let near=false;
+        for (let oy=-1;oy<=1;oy++) for (let ox=-1;ox<=1;ox++) {
+          if (d[idx(x+ox,y+oy)+3]>0) near=true;
+        }
+        if (near) { out[i]=col.r; out[i+1]=col.g; out[i+2]=col.b; out[i+3]=255; }
+      }
     }
+    for (let i=0;i<d.length;i++) if (out[i+3]) d[i]=out[i], d[i+1]=out[i+1], d[i+2]=out[i+2], d[i+3]=out[i+3];
   }
+  function hexToRgb(hex){const n=parseInt(hex.slice(1),16);return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};}
 
-  function drawEyes(ctx, x, y, color, glow) {
-    px(ctx, x, y, glow); px(ctx, x+1, y, color);
-    px(ctx, x+3, y, glow); px(ctx, x+4, y, color);
-  }
-
-  function drawWings(ctx, x, y, w, h, c, r, alpha) {
-    ctx.save();
-    ctx.globalAlpha = alpha;
-    rect(ctx, x, y, w, h, c);
-    rect(ctx, x+1, y+1, w-2, h-2, shade(c, 20));
-    ctx.restore();
-  }
-
-  function drawMushroom(ctx, frame, r) {
-    const cap = '#8e44ad';
-    const capShadow = shade(cap, -30);
-    const capLight = shade(cap, 30);
-    const stem = '#f5f2e8';
-    const stemShadow = shade(stem, -30);
-    const outline = '#0b0f1c';
-    const wobble = frame === 1 ? -1 : 0;
-    const squash = frame === 2 ? 2 : 0;
-    drawOutlinedCircle(ctx, 16+wobble, 14, 8-squash, cap, outline, capLight);
-    drawDitheredFill(ctx, 9, 12, 14, 5, cap, capShadow);
-    rect(ctx, 11+wobble, 20, 10, 8, stem);
-    rect(ctx, 11+wobble, 26, 10, 2, stemShadow);
-    circleSpots(ctx, 16+wobble, 13, 3, '#fff', outline, r);
-    drawEyes(ctx, 13+wobble, 21, '#111', '#fff');
-  }
-
-  function drawSlime(ctx, frame, r, tint) {
-    const base = tint || '#2ecc71';
-    const shadow = shade(base, -40);
-    const highlight = shade(base, 40);
-    const outline = '#0b0f1c';
-    const tall = frame === 1 ? -2 : 0;
-    const wide = frame === 2 ? 2 : 0;
-    drawShadedRect(ctx, 9-wide, 16+tall, 14+wide*2, 10-tall, base, shadow, highlight, outline);
-    drawOutlinedCircle(ctx, 12, 18+tall, 4, shade(base, -60), outline, highlight);
-    drawOutlinedCircle(ctx, 17, 18+tall, 4, shade(base, -60), outline, highlight);
-    px(ctx, 14, 12+tall, highlight); px(ctx, 15, 12+tall, highlight);
-    rect(ctx, 14, 26, 4, 2, shadow);
-  }
-
-  function drawSpider(ctx, frame, r) {
-    const body = '#3b3f5c';
-    const shadow = shade(body, -30);
-    const highlight = shade(body, 30);
-    const outline = '#0b0f1c';
-    drawOutlinedCircle(ctx, 14, 18, 4, body, outline, highlight);
-    drawOutlinedCircle(ctx, 20, 20, 5, shadow, outline, highlight);
-    for (let i=0;i<4;i++) {
-      const y = frame === 1 ? 16+i%2 : 18-i%2;
-      rect(ctx, 4+i*2, y, 6, 1, outline);
-      rect(ctx, 22+i*2, y+1, 6, 1, outline);
-    }
-    rect(ctx, 17, 19, 6, 1, highlight);
-    drawEyes(ctx, 12, 18, '#e74c3c', '#fff');
-  }
-
-  function drawBombMushroom(ctx, frame, r) {
-    drawMushroom(ctx, frame, r);
-    rect(ctx, 15, 6, 2, 4, '#8b5a2b');
-    const spark = frame === 1 ? '#f8d36a' : '#e74c3c';
-    px(ctx, 14, 5, spark); px(ctx, 17, 5, spark);
-    rect(ctx, 12, 22, 4, 1, '#000'); rect(ctx, 18, 22, 4, 1, '#000');
-    if (frame === 2) drawDitheredFill(ctx, 10, 10, 12, 6, '#fff', '#f8d36a');
-  }
-
-  function drawDarkSlime(ctx, frame, r) {
-    drawSlime(ctx, frame, r, '#2b2f44');
-    const glow = frame === 1 ? '#f1c40f' : '#f8d36a';
-    drawEyes(ctx, 12, 20, glow, '#fff');
-    rect(ctx, 8, 14, 2, 2, '#6c2eb9');
-  }
-
-  function drawBat(ctx, frame, r) {
-    const body = '#4f4c6a';
-    const outline = '#0b0f1c';
-    const wing = '#2b2f44';
-    const spread = frame === 1 ? 1 : 0;
-    rect(ctx, 14, 16, 4, 5, body);
-    rect(ctx, 6-spread*2, 15-spread, 8+spread*2, 3, wing);
-    rect(ctx, 18, 15-spread, 8+spread*2, 3, wing);
-    rect(ctx, 6-spread*2, 18, 8+spread*2, 2, outline);
-    px(ctx, 15, 16, '#fff'); px(ctx, 17, 16, '#fff');
-    rect(ctx, 14, 14, 1, 2, outline); rect(ctx, 17, 14, 1, 2, outline);
-    if (frame === 2) rect(ctx, 10, 18, 12, 2, outline);
-  }
-
-  function drawIceWorm(ctx, frame, r) {
-    const base = '#5dade2';
-    const shadow = shade(base, -30);
-    const highlight = shade(base, 30);
-    const outline = '#0b0f1c';
-    const bend = frame === 1 ? 1 : frame === 2 ? -1 : 0;
-    for (let i=0;i<4;i++) {
-      drawOutlinedCircle(ctx, 10+i*5, 18+((i%2)+bend), 3, base, outline, highlight);
-    }
-    rect(ctx, 6, 18, 2, 2, '#f8f8ff');
-    rect(ctx, 7, 16, 1, 4, '#f8f8ff');
-  }
-
-  function drawDarkFlower(ctx, frame, r) {
-    const petal = '#4a235a';
-    const edge = '#e74c3c';
-    const center = '#f1c40f';
-    const outline = '#0b0f1c';
-    for (let i=0;i<8;i++) {
-      const pxX = 16 + Math.round(Math.cos(i)*6);
-      const pxY = 16 + Math.round(Math.sin(i)*6);
-      px(ctx, pxX, pxY, petal); px(ctx, pxX+1, pxY, edge);
-    }
-    drawOutlinedCircle(ctx, 16, 16, 3, center, outline, '#fff');
-    rect(ctx, 15, 20, 2, 8, '#2d5a1e');
-    if (frame === 1) rect(ctx, 12, 12, 8, 2, edge);
-    if (frame === 2) rect(ctx, 14, 18, 4, 1, '#000');
-  }
-
-  function drawShadowBee(ctx, frame, r) {
-    const body = '#1a1a2a';
-    const stripe = '#3b3f5c';
-    const outline = '#0b0f1c';
-    drawShadedRect(ctx, 12, 16, 8, 6, body, outline, stripe, outline);
-    rect(ctx, 12, 18, 8, 1, stripe);
-    const wingY = frame === 1 ? 10 : 12;
-    drawWings(ctx, 9, wingY, 6, 3, '#85c1e9', r, 0.5);
-    drawWings(ctx, 17, wingY, 6, 3, '#85c1e9', r, 0.5);
-    rect(ctx, 19, 21, 2, 2, '#e74c3c');
-    if (frame === 2) rect(ctx, 20, 22, 4, 1, '#f8d36a');
+  function cuteBody(ctx, cx, cy, headR, bodyR, base, outline){
+    const shadow = shade(base, -0.12);
+    const highlight = shade(base, 0.12);
+    drawCircle(ctx, cx, cy, headR, base);
+    drawCircle(ctx, cx, cy+10, bodyR, base);
+    dither(ctx, cx-headR+2, cy+2, headR, headR, base, shadow);
+    drawCircle(ctx, cx-3, cy-3, 2, highlight);
+    drawOutline(ctx, ctx.getImageData(0,0,32,32), outline);
   }
 
   function drawEnemy(ctx, type, frame, r) {
-    switch (type) {
-      case 'poison_mushroom': drawMushroom(ctx, frame, r); break;
-      case 'green_slime': drawSlime(ctx, frame, r, '#2ecc71'); break;
-      case 'spider': drawSpider(ctx, frame, r); break;
-      case 'bomb_mushroom': drawBombMushroom(ctx, frame, r); break;
-      case 'dark_slime': drawDarkSlime(ctx, frame, r); break;
-      case 'bat': drawBat(ctx, frame, r); break;
-      case 'ice_worm': drawIceWorm(ctx, frame, r); break;
-      case 'dark_flower': drawDarkFlower(ctx, frame, r); break;
-      case 'shadow_bee': drawShadowBee(ctx, frame, r); break;
+    const outline = '#2A2A4A';
+    if (type === 'poison_mushroom') {
+      const cap = '#ff6b8a';
+      const capS = shade(cap,-0.1);
+      const stem = '#fff1d6';
+      const hop = frame===1?-1:frame===2?1:0;
+      drawRoundedRect(ctx, 8, 8+hop, 16, 12, 6, cap);
+      dither(ctx, 9, 12+hop, 14, 4, cap, capS);
+      drawRoundedRect(ctx, 12, 18+hop, 8, 10, 4, stem);
+      drawCircle(ctx, 12, 12+hop, 2, '#fff');
+      drawCircle(ctx, 20, 13+hop, 2, '#fff');
+      drawEye(ctx, 14, 20+hop, 2, '#5b3a29', 'left');
+      drawEye(ctx, 18, 20+hop, 2, '#5b3a29', 'right');
+      drawCheek(ctx, 12, 22+hop); drawCheek(ctx, 20, 22+hop);
+    }
+    if (type === 'green_slime') {
+      const base = '#9ee6a1';
+      const wob = frame===1?-1:frame===2?1:0;
+      drawRoundedRect(ctx, 8, 12+wob, 16, 14, 7, base);
+      drawCircle(ctx, 12, 14+wob, 3, '#fff');
+      drawCircle(ctx, 19, 15+wob, 3, '#fff');
+      drawEye(ctx, 12, 18+wob, 2, '#2A2A4A', 'left');
+      drawEye(ctx, 18, 18+wob, 2, '#2A2A4A', 'right');
+      drawCheek(ctx, 10, 20+wob); drawCheek(ctx, 20, 20+wob);
+    }
+    if (type === 'spider') {
+      const base = '#d7bde2';
+      drawCircle(ctx, 16, 16, 7, base);
+      for (let i=0;i<8;i++){ const dx = i<4?-6:-2; const dy = i%2?2:-1; drawRoundedRect(ctx, 6+i*2, 20+dy, 3, 2, 1, '#7f8c8d'); }
+      drawEye(ctx, 13, 14, 2, '#ff5a5f', 'left');
+      drawEye(ctx, 19, 14, 2, '#ff5a5f', 'right');
+      drawCheek(ctx, 12, 17); drawCheek(ctx, 20, 17);
+    }
+    if (type === 'bomb_mushroom') {
+      const cap = '#2a2a4a';
+      const stem = '#f5f2e8';
+      const blink = frame===1;
+      drawRoundedRect(ctx, 8, 8, 16, 12, 6, cap);
+      drawRoundedRect(ctx, 12, 18, 8, 10, 4, stem);
+      drawRoundedRect(ctx, 15, 4, 2, 4, 1, '#8b5a2b');
+      drawCircle(ctx, 16, 3, 2, blink?'#ff5a5f':'#f1c40f');
+      drawEye(ctx, 13, 20, 2, '#ff5a5f', 'left');
+      drawEye(ctx, 19, 20, 2, '#ff5a5f', 'right');
+      drawCheek(ctx, 12, 22); drawCheek(ctx, 20, 22);
+    }
+    if (type === 'dark_slime') {
+      const base = '#a68bdc';
+      drawRoundedRect(ctx, 8, 12, 16, 14, 7, base);
+      drawEye(ctx, 12, 18, 2, '#ff5a5f', 'left');
+      drawEye(ctx, 18, 18, 2, '#ff5a5f', 'right');
+      dither(ctx, 8, 10, 16, 4, '#6c2eb9', base);
+    }
+    if (type === 'bat') {
+      const base = '#f7c6e3';
+      drawRoundedRect(ctx, 12, 14, 8, 10, 5, base);
+      drawRoundedRect(ctx, 4, 12, 10, 6, 4, '#d7bde2');
+      drawRoundedRect(ctx, 18, 12, 10, 6, 4, '#d7bde2');
+      drawEye(ctx, 13, 16, 2, '#2A2A4A', 'left');
+      drawEye(ctx, 19, 16, 2, '#2A2A4A', 'right');
+      drawCheek(ctx, 12, 19); drawCheek(ctx, 20, 19);
+    }
+    if (type === 'ice_worm') {
+      for (let i=0;i<4;i++) drawCircle(ctx, 10+i*5, 16+i%2, 4, '#bfe4ff');
+      drawEye(ctx, 8, 14, 2, '#3498db', 'left');
+      drawEye(ctx, 12, 14, 2, '#3498db', 'right');
+      drawCheek(ctx, 9, 17); drawCheek(ctx, 13, 17);
+    }
+    if (type === 'dark_flower') {
+      for (let i=0;i<8;i++) drawCircle(ctx, 16+Math.round(Math.cos(i)*6), 16+Math.round(Math.sin(i)*6), 2, '#4a235a');
+      drawCircle(ctx, 16, 16, 4, '#f1c40f');
+      drawEye(ctx, 14, 15, 2, '#2A2A4A', 'left');
+      drawEye(ctx, 18, 15, 2, '#2A2A4A', 'right');
+      drawCheek(ctx, 13, 18); drawCheek(ctx, 19, 18);
+    }
+    if (type === 'shadow_bee') {
+      drawRoundedRect(ctx, 10, 14, 12, 10, 5, '#2a2a4a');
+      drawRoundedRect(ctx, 8, 10, 6, 4, 2, '#aed6f1');
+      drawRoundedRect(ctx, 18, 10, 6, 4, 2, '#aed6f1');
+      drawEye(ctx, 12, 16, 2, '#ff5a5f', 'left');
+      drawEye(ctx, 18, 16, 2, '#ff5a5f', 'right');
+      drawCheek(ctx, 12, 19); drawCheek(ctx, 20, 19);
     }
   }
 
   function drawNpc(ctx, type, frame, r) {
-    const base = {
-      hatch:'#f5a623', miel:'#9b59b6', marche:'#e67e22', bee:'#f8d36a',
-      pore:'#8b7355', navi:'#1abc9c', granpa:'#bdc3c7', sign:'#6b5b3a'
-    }[type];
-    const outline = '#0b0f1c';
-    if (type === 'sign') {
-      drawShadedRect(ctx, 12, 10, 8, 16, base, shade(base,-30), shade(base,20), outline);
-      drawShadedRect(ctx, 6, 8, 20, 6, '#c4a035', '#8b5a2b', '#f8d36a', outline);
-      rect(ctx, 10, 24, 12, 2, '#1a1a2a');
-      return;
+    const outline = '#5B3A29';
+    const bounce = frame===1?-1:0;
+    if (type === 'elder') {
+      cuteBody(ctx, 16, 12+bounce, 7, 6, '#f5a623', outline);
+      drawRoundedRect(ctx, 8, 20+bounce, 2, 10, 1, '#8b5a2b');
+      drawCircle(ctx, 12, 10+bounce, 1, '#fff');
+      drawCircle(ctx, 20, 10+bounce, 1, '#fff');
+      drawRoundedRect(ctx, 12, 22+bounce, 8, 4, 2, '#f5f2e8');
     }
-    drawShadedRect(ctx, 12, 14, 8, 10, base, shade(base,-30), shade(base,30), outline);
-    drawShadedRect(ctx, 11, 12, 10, 4, base, shade(base,-30), shade(base,30), outline);
-    rect(ctx, 9, 12, 3, 3, '#85c1e9');
-    rect(ctx, 20, 12, 3, 3, '#85c1e9');
-    if (frame === 1) rect(ctx, 14, 20, 4, 2, '#000');
-    drawEyes(ctx, 13, 16, '#111', '#fff');
-    if (type === 'hatch') { rect(ctx, 10, 10, 1, 10, '#daa520'); rect(ctx, 12, 12, 2, 1, '#000'); rect(ctx, 18, 12, 2, 1, '#000'); }
-    if (type === 'miel') { drawOutlinedCircle(ctx, 23, 20, 3, '#85c1e9', outline, '#fff'); }
-    if (type === 'marche') { rect(ctx, 11, 20, 10, 4, '#8b7355'); if (frame===1) rect(ctx, 20, 18, 4, 3, '#f8d36a'); }
-    if (type === 'bee') { rect(ctx, 12, 18, 8, 1, '#000'); if (frame===1) rect(ctx, 8, 12, 3, 3, '#f8f8ff'); }
-    if (type === 'pore') { if (frame===1) rect(ctx, 14, 10, 4, 2, '#f5f2e8'); }
-    if (type === 'navi') { rect(ctx, 14, 18, 4, 2, '#85c1e9'); if (frame===1) rect(ctx, 8, 10, 3, 3, '#85c1e9'); }
-    if (type === 'granpa') { rect(ctx, 12, 20, 8, 3, '#f5f2e8'); if (frame===1) rect(ctx, 14, 19, 4, 1, '#f5f2e8'); }
+    if (type === 'merchant') {
+      cuteBody(ctx, 16, 12+bounce, 7, 6, '#e67e22', outline);
+      drawRoundedRect(ctx, 12, 18+bounce, 8, 6, 2, '#8b7355');
+      if (frame===1) drawRoundedRect(ctx, 20, 18+bounce, 6, 4, 2, '#f8d36a');
+    }
+    if (type === 'healer') {
+      cuteBody(ctx, 16, 12+bounce, 7, 6, '#f5f2e8', outline);
+      drawRoundedRect(ctx, 14, 16+bounce, 4, 4, 1, '#e74c3c');
+    }
+    if (type === 'guard') {
+      cuteBody(ctx, 16, 12+bounce, 7, 6, '#708090', outline);
+      drawRoundedRect(ctx, 22, 14+bounce, 2, 12, 1, '#c4a035');
+    }
+    if (type === 'child') {
+      drawCircle(ctx, 16, 12+bounce, 6, '#f8d36a');
+      drawCircle(ctx, 16, 22+bounce, 5, '#f8d36a');
+      drawEye(ctx, 13, 12+bounce, 2, '#2A2A4A', 'left');
+      drawEye(ctx, 19, 12+bounce, 2, '#2A2A4A', 'right');
+      drawCheek(ctx, 12, 15+bounce); drawCheek(ctx, 20, 15+bounce);
+    }
+    if (type === 'fairy') {
+      cuteBody(ctx, 16, 12+bounce, 6, 5, '#1abc9c', outline);
+      drawRoundedRect(ctx, 8, 10+bounce, 4, 3, 2, '#aed6f1');
+      drawRoundedRect(ctx, 20, 10+bounce, 4, 3, 2, '#aed6f1');
+      drawCircle(ctx, 24, 6+bounce, 1, '#f1c40f');
+    }
+    if (type === 'cat') {
+      drawCircle(ctx, 16, 14+bounce, 7, '#f5cba7');
+      drawRoundedRect(ctx, 10, 6+bounce, 4, 4, 1, '#f5cba7');
+      drawRoundedRect(ctx, 18, 6+bounce, 4, 4, 1, '#f5cba7');
+      drawEye(ctx, 13, 13+bounce, 2, '#2A2A4A', 'left');
+      drawEye(ctx, 19, 13+bounce, 2, '#2A2A4A', 'right');
+      if (frame===1) drawRoundedRect(ctx, 6, 20+bounce, 6, 2, 1, '#f5cba7');
+    }
+    if (type === 'mushroom_friend') {
+      drawEnemy(ctx, 'poison_mushroom', 0, r);
+      drawCircle(ctx, 16, 20, 2, '#fff');
+    }
   }
 
   function drawBoss(ctx, type, frame, r) {
-    const outline = '#0b0f1c';
+    const outline = '#2A2A4A';
     if (type === 'mushroom_king') {
-      drawOutlinedCircle(ctx, 32, 22, 18, '#c0392b', outline, '#ff7675');
-      drawDitheredFill(ctx, 18, 16, 28, 8, '#e74c3c', '#c0392b');
-      drawShadedRect(ctx, 24, 32, 16, 20, '#f5f2e8', '#8b5a2b', '#fff', outline);
-      drawShadedRect(ctx, 26, 8, 12, 6, '#f1c40f', '#d4a03c', '#f8d36a', outline);
-      if (frame === 1) rect(ctx, 20, 20, 24, 2, '#000');
-      if (frame === 2) drawDitheredFill(ctx, 16, 6, 32, 8, '#f8f8ff', '#f8d36a');
-      if (frame === 3) rect(ctx, 28, 8, 12, 2, '#000');
+      drawCircle(ctx, 32, 22, 18, '#ff6b8a');
+      drawRoundedRect(ctx, 24, 34, 16, 20, 6, '#fff1d6');
+      drawRoundedRect(ctx, 26, 10, 12, 6, 2, '#f1c40f');
+      if (frame===1) drawRoundedRect(ctx, 24, 20, 16, 2, 1, '#c0392b');
+      if (frame===2) dither(ctx, 14, 6, 36, 8, '#fff8ff', '#f8d36a');
+      if (frame===3) drawRoundedRect(ctx, 28, 10, 12, 2, 1, '#2A2A4A');
     }
     if (type === 'ice_beetle') {
-      drawShadedRect(ctx, 18, 24, 28, 24, '#5dade2', '#2980b9', '#85c1e9', outline);
-      drawShadedRect(ctx, 22, 18, 20, 8, '#85c1e9', '#5dade2', '#f8f8ff', outline);
-      rect(ctx, 12, 20, 6, 6, '#85c1e9'); rect(ctx, 46, 20, 6, 6, '#85c1e9');
-      if (frame === 2) rect(ctx, 26, 10, 12, 6, '#f8f8ff');
-      if (frame === 3) rect(ctx, 18, 24, 28, 1, '#000');
+      drawRoundedRect(ctx, 16, 24, 32, 26, 10, '#85c1e9');
+      drawRoundedRect(ctx, 22, 18, 20, 8, 4, '#bfe4ff');
+      if (frame===2) drawRoundedRect(ctx, 26, 10, 12, 6, 2, '#f8f8ff');
+      if (frame===3) drawRoundedRect(ctx, 18, 26, 28, 2, 1, '#5dade2');
     }
     if (type === 'dark_queen') {
-      drawShadedRect(ctx, 18, 22, 28, 28, '#1a1a2a', '#0b0f1c', '#3b3f5c', outline);
-      drawShadedRect(ctx, 20, 18, 24, 6, '#6c2eb9', '#4a235a', '#9b59b6', outline);
-      rect(ctx, 10, 18, 6, 10, '#3b3f5c'); rect(ctx, 48, 18, 6, 10, '#3b3f5c');
-      if (frame === 1) drawDitheredFill(ctx, 10, 8, 44, 6, '#6c2eb9', '#4a235a');
-      if (frame === 2) rect(ctx, 26, 12, 12, 4, '#f8d36a');
-      if (frame === 3) rect(ctx, 24, 30, 16, 2, '#f5f2e8');
+      drawRoundedRect(ctx, 18, 22, 28, 28, 10, '#3b3f5c');
+      drawRoundedRect(ctx, 20, 18, 24, 6, 3, '#6c2eb9');
+      drawRoundedRect(ctx, 8, 18, 6, 10, 2, '#4f4c6a');
+      drawRoundedRect(ctx, 50, 18, 6, 10, 2, '#4f4c6a');
+      if (frame===1) dither(ctx, 10, 8, 44, 6, '#6c2eb9', '#4a235a');
+      if (frame===2) drawRoundedRect(ctx, 26, 12, 12, 4, 2, '#f8d36a');
+      if (frame===3) drawRoundedRect(ctx, 24, 32, 16, 2, 1, '#f5f2e8');
     }
+  }
+
+  function drawPlayer(ctx, frame, r) {
+    const body = '#f8d36a';
+    const stripe = '#2A2A4A';
+    const wing = '#aed6f1';
+    const y = frame%3===1?-1:0;
+    const dir = Math.floor(frame/3);
+    drawRoundedRect(ctx, 12, 10+y, 8, 8, 4, body);
+    drawRoundedRect(ctx, 12, 18+y, 8, 8, 4, body);
+    drawRoundedRect(ctx, 12, 14+y, 8, 2, 1, stripe);
+    drawEye(ctx, 13, 12+y, 2, '#2A2A4A', 'left');
+    drawEye(ctx, 19, 12+y, 2, '#2A2A4A', 'right');
+    drawCheek(ctx, 12, 15+y); drawCheek(ctx, 20, 15+y);
+    if (dir===0) drawRoundedRect(ctx, 8, 10+y, 4, 3, 2, wing);
+    if (dir===1) drawRoundedRect(ctx, 20, 10+y, 4, 3, 2, wing);
+    if (dir===2) drawRoundedRect(ctx, 10, 9+y, 5, 3, 2, wing);
+    if (dir===3) drawRoundedRect(ctx, 17, 9+y, 5, 3, 2, wing);
   }
 
   function drawTile(ctx, type, r) {
-    const outline = '#0b0f1c';
     if (type === 'grass') {
-      drawDitheredFill(ctx, 0, 0, 32, 32, '#4a8c2a', '#3d7a22');
-      for (let i=0;i<12;i++) px(ctx, Math.floor(r()*32), Math.floor(r()*32), '#7dcea0');
+      dither(ctx,0,0,32,32,'#9ee6a1','#6acb6e');
+      for (let i=0;i<6;i++) drawCircle(ctx, Math.floor(randRange(r,4,28)), Math.floor(randRange(r,4,28)), 1, '#ffb3c1');
     }
     if (type === 'path') {
-      drawDitheredFill(ctx, 0, 0, 32, 32, '#c4a035', '#b7950b');
-      rect(ctx, 10, 14, 12, 4, '#d7bde2');
+      dither(ctx,0,0,32,32,'#d5b88c','#c4a035');
+      drawCircle(ctx, 10, 20, 1, '#7f8c8d');
     }
     if (type === 'wall') {
-      rect(ctx, 0, 0, 32, 32, '#6b5b3a');
-      for (let y=0;y<32;y+=8) rect(ctx, 0, y, 32, 1, '#4a3a28');
-      for (let x=0;x<32;x+=8) rect(ctx, x, 0, 1, 32, '#4a3a28');
-      rect(ctx, 4, 4, 4, 2, '#2ecc71');
+      dither(ctx,0,0,32,32,'#6b5b3a','#8b7355');
+      for (let y=0;y<32;y+=8) dither(ctx,0,y,32,1,'#4a3a28','#6b5b3a');
     }
     if (type === 'water') {
-      drawDitheredFill(ctx, 0, 0, 32, 32, '#3a7ecf', '#2980b9');
-      for (let i=0;i<32;i+=6) rect(ctx, i, 10, 4, 1, '#85c1e9');
-      for (let i=0;i<32;i+=7) rect(ctx, i, 20, 4, 1, '#5dade2');
+      dither(ctx,0,0,32,32,'#5dade2','#2980b9');
+      for (let i=0;i<32;i+=6) drawRoundedRect(ctx,i,10,4,1,1,'#e8f6ff');
     }
     if (type === 'tree') {
-      rect(ctx, 12, 18, 8, 10, '#6b5b3a');
-      drawOutlinedCircle(ctx, 16, 14, 9, '#2d5a1e', outline, '#7dcea0');
+      drawRoundedRect(ctx, 12, 18, 8, 10, 3, '#8b7355');
+      drawCircle(ctx, 16, 14, 9, '#2ecc71');
     }
     if (type === 'house') {
-      drawShadedRect(ctx, 8, 14, 16, 12, '#8b7355', '#6b5b3a', '#c4a035', outline);
-      rect(ctx, 10, 10, 12, 6, '#6b5b3a');
-      rect(ctx, 12, 18, 4, 6, '#0b0f1c');
-      rect(ctx, 18, 18, 4, 4, '#f8f8ff');
+      drawRoundedRect(ctx, 8, 14, 16, 12, 3, '#8b7355');
+      drawRoundedRect(ctx, 10, 10, 12, 6, 2, '#6b5b3a');
+      drawRoundedRect(ctx, 12, 18, 4, 6, 1, '#2A2A4A');
+      drawRoundedRect(ctx, 18, 18, 4, 4, 1, '#e8f6ff');
     }
     if (type === 'fence') {
-      rect(ctx, 8, 8, 2, 16, '#6b5b3a'); rect(ctx, 22, 8, 2, 16, '#6b5b3a'); rect(ctx, 8, 12, 16, 2, '#8b7355');
+      drawRoundedRect(ctx, 8, 8, 2, 16, 1, '#8b7355');
+      drawRoundedRect(ctx, 22, 8, 2, 16, 1, '#8b7355');
+      drawRoundedRect(ctx, 8, 12, 16, 2, 1, '#6b5b3a');
     }
     if (type === 'well') {
-      drawOutlinedCircle(ctx, 16, 18, 6, '#708090', outline, '#d1d8e0');
-      rect(ctx, 12, 16, 8, 4, '#0b0f1c');
-      rect(ctx, 18, 10, 1, 6, '#8b7355'); rect(ctx, 12, 10, 1, 6, '#8b7355');
+      drawCircle(ctx, 16, 18, 6, '#708090');
+      drawRoundedRect(ctx, 12, 16, 8, 4, 2, '#2A2A4A');
     }
     if (type === 'flower') {
-      drawDitheredFill(ctx, 0, 0, 32, 32, '#4a8c2a', '#3d7a22');
-      for (let i=0;i<6;i++) { px(ctx, 10+i*3, 16, '#ff5a5f'); px(ctx, 11+i*3, 15, '#f8d36a'); }
+      dither(ctx,0,0,32,32,'#9ee6a1','#6acb6e');
+      for (let i=0;i<6;i++) drawCircle(ctx, 8+i*4, 16, 1, pick(palette.accent, r));
     }
     if (type === 'bridge') {
-      rect(ctx, 0, 0, 32, 32, '#8b7355');
-      for (let i=0;i<32;i+=4) rect(ctx, i, 14, 2, 6, '#6b5b3a');
-      rect(ctx, 4, 8, 24, 1, '#f5f2e8'); rect(ctx, 4, 24, 24, 1, '#f5f2e8');
+      dither(ctx,0,0,32,32,'#8b7355','#6b5b3a');
+      for (let i=0;i<32;i+=4) drawRoundedRect(ctx,i,14,2,6,1,'#5B3A29');
     }
     if (type === 'save_point') {
-      rect(ctx, 12, 20, 8, 6, '#6b5b3a');
-      drawOutlinedCircle(ctx, 16, 14, 6, '#f8d36a', outline, '#fff');
-      rect(ctx, 16, 6, 1, 4, '#f8f8ff');
+      drawRoundedRect(ctx, 12, 20, 8, 6, 2, '#8b7355');
+      drawCircle(ctx, 16, 14, 6, '#f8d36a');
+      drawRoundedRect(ctx, 16, 6, 1, 4, 1, '#fff8ff');
     }
     if (type === 'sign') {
-      rect(ctx, 14, 10, 4, 12, '#8b7355'); rect(ctx, 8, 8, 16, 6, '#c4a035');
+      drawRoundedRect(ctx, 14, 10, 4, 12, 1, '#8b7355');
+      drawRoundedRect(ctx, 8, 8, 16, 6, 2, '#c4a035');
     }
     if (type === 'chest') {
-      drawShadedRect(ctx, 8, 14, 16, 10, '#daa520', '#8b5a2b', '#f8d36a', outline);
-      rect(ctx, 8, 18, 16, 2, '#6b5b3a'); rect(ctx, 15, 18, 2, 4, '#f8f8ff');
+      drawRoundedRect(ctx, 8, 14, 16, 10, 3, '#daa520');
+      drawRoundedRect(ctx, 8, 18, 16, 2, 1, '#6b5b3a');
+      drawRoundedRect(ctx, 15, 18, 2, 4, 1, '#f8f8ff');
     }
     if (type === 'stump') {
-      drawOutlinedCircle(ctx, 16, 18, 6, '#6b5b3a', outline, '#8b7355');
-      rect(ctx, 12, 16, 8, 4, '#c4a035');
-      rect(ctx, 10, 20, 2, 2, '#2ecc71');
+      drawCircle(ctx, 16, 18, 6, '#6b5b3a');
+      drawRoundedRect(ctx, 12, 16, 8, 4, 2, '#c4a035');
     }
     if (type === 'bush') {
-      drawOutlinedCircle(ctx, 12, 18, 5, '#3d7a22', outline, '#7dcea0');
-      drawOutlinedCircle(ctx, 20, 18, 5, '#3d7a22', outline, '#7dcea0');
-      px(ctx, 14, 16, '#ff5a5f'); px(ctx, 18, 19, '#ff5a5f');
+      drawCircle(ctx, 12, 18, 5, '#2ecc71');
+      drawCircle(ctx, 20, 18, 5, '#2ecc71');
+      drawCircle(ctx, 14, 16, 1, '#ff5a5f');
+      drawCircle(ctx, 18, 20, 1, '#ff5a5f');
     }
     if (type === 'cave_floor') {
-      drawDitheredFill(ctx, 0, 0, 32, 32, '#3b3f5c', '#2b2f44');
-      rect(ctx, 8, 8, 6, 1, '#0b0f1c'); rect(ctx, 18, 22, 8, 1, '#0b0f1c');
+      dither(ctx,0,0,32,32,'#3b3f5c','#2b2f44');
+      drawRoundedRect(ctx, 8, 8, 6, 1, 1, '#1a1a2a');
     }
     if (type === 'anchor') {
-      rect(ctx, 15, 8, 2, 16, '#708090'); rect(ctx, 10, 20, 12, 2, '#708090');
-      rect(ctx, 12, 22, 2, 4, '#708090'); rect(ctx, 18, 22, 2, 4, '#708090');
+      drawRoundedRect(ctx, 15, 8, 2, 16, 1, '#708090');
+      drawRoundedRect(ctx, 10, 20, 12, 2, 1, '#708090');
     }
     if (type === 'seal_wall') {
-      drawShadedRect(ctx, 4, 4, 24, 24, '#2ecc71', '#145a32', '#7dcea0', outline);
-      for (let i=8;i<24;i+=6) rect(ctx, i, 10, 2, 8, '#f8f8ff');
+      drawRoundedRect(ctx, 4, 4, 24, 24, 4, '#2ecc71');
+      for (let i=8;i<24;i+=6) drawRoundedRect(ctx, i, 10, 2, 8, 1, '#f8f8ff');
     }
     if (type === 'exit') {
-      rect(ctx, 6, 6, 20, 20, '#2ecc71'); rect(ctx, 10, 10, 12, 12, '#0b0f1c');
-      rect(ctx, 12, 14, 8, 1, '#f8f8ff');
-    }
-  }
-
-  function circleSpots(ctx, cx, cy, count, c, outline, r) {
-    for (let i=0;i<count;i++) {
-      const ox = Math.round(randRange(r, -6, 6));
-      const oy = Math.round(randRange(r, -4, 4));
-      drawOutlinedCircle(ctx, cx+ox, cy+oy, 2, c, outline, '#f8f8ff');
+      drawRoundedRect(ctx, 6, 6, 20, 20, 4, '#2ecc71');
+      drawRoundedRect(ctx, 10, 10, 12, 12, 2, '#1a1a2a');
     }
   }
 
@@ -509,10 +526,10 @@
         frames.push({ sx, sy, sw: frameW, sh: frameH });
       }
       const base = i * framesPer;
-      animations[names[i] + '_idle'] = { frames: [base], fps: 6, loop: true };
-      if (framesPer > 1) animations[names[i] + '_move'] = { frames: [base, base+1], fps: 8, loop: true };
-      if (framesPer > 2) animations[names[i] + '_hurt'] = { frames: [base+2], fps: 4, loop: false };
-      if (framesPer > 3) animations[names[i] + '_special'] = { frames: [base+2, base+3], fps: 6, loop: false };
+      animations[names[i] + '_idle'] = { frames: [base], fps: 3, loop: true };
+      if (framesPer > 1) animations[names[i] + '_move'] = { frames: [base, base+1], fps: 3, loop: true };
+      if (framesPer > 2) animations[names[i] + '_hurt'] = { frames: [base+2], fps: 3, loop: false };
+      if (framesPer > 3) animations[names[i] + '_special'] = { frames: [base+2, base+3], fps: 3, loop: false };
     }
     return { sheet: { w: sheetW, h: sheetH, frameW, frameH }, frames, animations };
   }
@@ -525,8 +542,7 @@
     ctx.imageSmoothingEnabled = false;
     for (let i=0;i<names.length;i++) {
       for (let f=0;f<framesPer;f++) {
-        ctx.save();
-        ctx.translate(f*frameW, i*frameH);
+        ctx.save(); ctx.translate(f*frameW, i*frameH);
         drawFn(ctx, names[i], f, r);
         ctx.restore();
       }
@@ -535,20 +551,25 @@
     canvas.style.height = canvas.height * zoom + 'px';
   }
 
-  function renderTiles(canvas, zoom, r) {
-    const cols = 10;
-    const rows = Math.ceil(tileTypes.length / cols);
-    canvas.width = cols * 32;
-    canvas.height = rows * 32;
+  function renderPlayer(canvas, zoom, r) {
+    canvas.width = 32 * 14;
+    canvas.height = 32;
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0,0,canvas.width, canvas.height);
+    for (let i=0;i<14;i++) {
+      ctx.save(); ctx.translate(i*32, 0); drawPlayer(ctx, i, r); ctx.restore();
+    }
+    canvas.style.width = canvas.width * zoom + 'px';
+    canvas.style.height = canvas.height * zoom + 'px';
+  }
+
+  function renderTiles(canvas, zoom, r) {
+    const cols = 10; const rows = Math.ceil(tileTypes.length / cols);
+    canvas.width = cols * 32; canvas.height = rows * 32;
+    const ctx = canvas.getContext('2d'); ctx.clearRect(0,0,canvas.width, canvas.height);
     for (let i=0;i<tileTypes.length;i++) {
-      const x = (i % cols) * 32;
-      const y = Math.floor(i / cols) * 32;
-      ctx.save();
-      ctx.translate(x, y);
-      drawTile(ctx, tileTypes[i], r);
-      ctx.restore();
+      const x = (i % cols) * 32; const y = Math.floor(i / cols) * 32;
+      ctx.save(); ctx.translate(x, y); drawTile(ctx, tileTypes[i], r); ctx.restore();
     }
     canvas.style.width = canvas.width * zoom + 'px';
     canvas.style.height = canvas.height * zoom + 'px';
@@ -557,17 +578,12 @@
   function buildPreview(container, names, size, frames, sheetCanvas) {
     container.innerHTML = '';
     for (let i=0;i<names.length;i++) {
-      const item = document.createElement('div');
-      item.className = 'preview-item';
-      const c = document.createElement('canvas');
-      c.width = size; c.height = size;
-      c.style.width = '64px'; c.style.height = '64px';
-      const label = document.createElement('div');
-      label.className = 'label';
-      label.textContent = names[i];
-      item.appendChild(c); item.appendChild(label);
-      container.appendChild(item);
-      item._canvas = c; item._index = i; item._frames = frames; item._size = size; item._sheet = sheetCanvas;
+      const item = document.createElement('div'); item.className='preview-item';
+      const c = document.createElement('canvas'); c.width=size; c.height=size; c.className='checker';
+      c.style.width='64px'; c.style.height='64px';
+      const label = document.createElement('div'); label.className='label'; label.textContent=names[i];
+      item.appendChild(c); item.appendChild(label); container.appendChild(item);
+      item._canvas=c; item._index=i; item._frames=frames; item._size=size; item._sheet=sheetCanvas;
     }
   }
 
@@ -576,8 +592,7 @@
       const c = item._canvas; if (!c) continue;
       const ctx = c.getContext('2d');
       const f = frameIndex % item._frames;
-      const sx = f * item._size;
-      const sy = item._index * item._size;
+      const sx = f * item._size; const sy = item._index * item._size;
       ctx.imageSmoothingEnabled = false;
       ctx.clearRect(0,0,c.width,c.height);
       ctx.drawImage(item._sheet, sx, sy, item._size, item._size, 0, 0, c.width, c.height);
@@ -589,28 +604,21 @@
     renderSheet(enemyCanvas, 32, 32, enemyTypes, 3, drawEnemy, parseInt(enemyZoom.value,10), r);
     renderSheet(npcCanvas, 32, 32, npcTypes, 2, drawNpc, parseInt(npcZoom.value,10), r);
     renderSheet(bossCanvas, 64, 64, bossTypes, 4, drawBoss, parseInt(bossZoom.value,10), r);
+    renderPlayer(playerCanvas, parseInt(playerZoom.value,10), r);
     renderTiles(tileCanvas, parseInt(tileZoom.value,10), r);
     buildPreview(enemyPreview, enemyTypes, 32, 3, enemyCanvas);
     buildPreview(npcPreview, npcTypes, 32, 2, npcCanvas);
-    updatePreview(enemyPreview, 0);
-    updatePreview(npcPreview, 0);
+    updatePreview(enemyPreview, 0); updatePreview(npcPreview, 0);
     tileLabels.innerHTML = '';
     tileTypes.forEach(t => { const d = document.createElement('div'); d.className='label'; d.textContent=t; tileLabels.appendChild(d); });
   }
 
   function downloadCanvas(canvas, name) {
-    const a = document.createElement('a');
-    a.download = name;
-    a.href = canvas.toDataURL('image/png');
-    a.click();
+    const a = document.createElement('a'); a.download = name; a.href = canvas.toDataURL('image/png'); a.click();
   }
-
   function downloadJson(data, name) {
     const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
-    const a = document.createElement('a');
-    a.download = name;
-    a.href = URL.createObjectURL(blob);
-    a.click();
+    const a = document.createElement('a'); a.download = name; a.href = URL.createObjectURL(blob); a.click();
     setTimeout(() => URL.revokeObjectURL(a.href), 1000);
   }
 
@@ -618,19 +626,25 @@
   document.getElementById('dlNpc').addEventListener('click', () => downloadCanvas(npcCanvas, 'npc_sheet.png'));
   document.getElementById('dlBoss').addEventListener('click', () => downloadCanvas(bossCanvas, 'boss_sheet.png'));
   document.getElementById('dlTiles').addEventListener('click', () => downloadCanvas(tileCanvas, 'tile_sheet.png'));
+  document.getElementById('dlPlayer').addEventListener('click', () => downloadCanvas(playerCanvas, 'player_sheet.png'));
 
-  document.getElementById('dlEnemyJson').addEventListener('click', () => {
-    downloadJson(makeJson(enemyCanvas.width, enemyCanvas.height, 32, 32, enemyTypes, 3), 'enemy_sheet.json');
-  });
-  document.getElementById('dlNpcJson').addEventListener('click', () => {
-    downloadJson(makeJson(npcCanvas.width, npcCanvas.height, 32, 32, npcTypes, 2), 'npc_sheet.json');
-  });
-  document.getElementById('dlBossJson').addEventListener('click', () => {
-    downloadJson(makeJson(bossCanvas.width, bossCanvas.height, 64, 64, bossTypes, 4), 'boss_sheet.json');
-  });
+  document.getElementById('dlEnemyJson').addEventListener('click', () => downloadJson(makeJson(enemyCanvas.width, enemyCanvas.height, 32, 32, enemyTypes, 3), 'enemy_sheet.json'));
+  document.getElementById('dlNpcJson').addEventListener('click', () => downloadJson(makeJson(npcCanvas.width, npcCanvas.height, 32, 32, npcTypes, 2), 'npc_sheet.json'));
+  document.getElementById('dlBossJson').addEventListener('click', () => downloadJson(makeJson(bossCanvas.width, bossCanvas.height, 64, 64, bossTypes, 4), 'boss_sheet.json'));
   document.getElementById('dlTilesJson').addEventListener('click', () => {
     const frames = tileTypes.map((t, i) => ({ name: t, sx:(i%10)*32, sy:Math.floor(i/10)*32, sw:32, sh:32 }));
     downloadJson({ sheet: { w: tileCanvas.width, h: tileCanvas.height, frameW: 32, frameH: 32 }, frames, animations: {} }, 'tile_sheet.json');
+  });
+  document.getElementById('dlPlayerJson').addEventListener('click', () => {
+    const frames = []; for (let i=0;i<14;i++) frames.push({ sx:i*32, sy:0, sw:32, sh:32 });
+    const animations = {
+      walk_down:{frames:[0,1,2],fps:3,loop:true},
+      walk_left:{frames:[3,4,5],fps:3,loop:true},
+      walk_right:{frames:[6,7,8],fps:3,loop:true},
+      walk_up:{frames:[9,10,11],fps:3,loop:true},
+      attack:{frames:[12,13],fps:3,loop:false}
+    };
+    downloadJson({ sheet:{w:playerCanvas.width,h:playerCanvas.height,frameW:32,frameH:32}, frames, animations }, 'player_sheet.json');
   });
 
   document.getElementById('downloadAll').addEventListener('click', async () => {
@@ -639,18 +653,18 @@
     zip.file('npc_sheet.png', npcCanvas.toDataURL('image/png').split(',')[1], {base64:true});
     zip.file('boss_sheet.png', bossCanvas.toDataURL('image/png').split(',')[1], {base64:true});
     zip.file('tile_sheet.png', tileCanvas.toDataURL('image/png').split(',')[1], {base64:true});
+    zip.file('player_sheet.png', playerCanvas.toDataURL('image/png').split(',')[1], {base64:true});
 
     zip.file('enemy_sheet.json', JSON.stringify(makeJson(enemyCanvas.width, enemyCanvas.height, 32, 32, enemyTypes, 3), null, 2));
     zip.file('npc_sheet.json', JSON.stringify(makeJson(npcCanvas.width, npcCanvas.height, 32, 32, npcTypes, 2), null, 2));
     zip.file('boss_sheet.json', JSON.stringify(makeJson(bossCanvas.width, bossCanvas.height, 64, 64, bossTypes, 4), null, 2));
     const tileFrames = tileTypes.map((t, i) => ({ name: t, sx:(i%10)*32, sy:Math.floor(i/10)*32, sw:32, sh:32 }));
     zip.file('tile_sheet.json', JSON.stringify({ sheet: { w: tileCanvas.width, h: tileCanvas.height, frameW:32, frameH:32 }, frames: tileFrames, animations:{} }, null, 2));
+    const pFrames = []; for (let i=0;i<14;i++) pFrames.push({ sx:i*32, sy:0, sw:32, sh:32 });
+    zip.file('player_sheet.json', JSON.stringify({ sheet:{w:playerCanvas.width,h:playerCanvas.height,frameW:32,frameH:32}, frames:pFrames, animations:{ walk_down:{frames:[0,1,2],fps:3,loop:true}, walk_left:{frames:[3,4,5],fps:3,loop:true}, walk_right:{frames:[6,7,8],fps:3,loop:true}, walk_up:{frames:[9,10,11],fps:3,loop:true}, attack:{frames:[12,13],fps:3,loop:false} } }, null, 2));
 
     const blob = await zip.generateAsync({type:'blob'});
-    const a = document.createElement('a');
-    a.download = 'sprite_sheets.zip';
-    a.href = URL.createObjectURL(blob);
-    a.click();
+    const a = document.createElement('a'); a.download = 'sprite_sheets_v3.zip'; a.href = URL.createObjectURL(blob); a.click();
     setTimeout(() => URL.revokeObjectURL(a.href), 1000);
   });
 
@@ -663,29 +677,28 @@
     bossCanvas.style.height = bossCanvas.height * parseInt(bossZoom.value,10) + 'px';
     tileCanvas.style.width = tileCanvas.width * parseInt(tileZoom.value,10) + 'px';
     tileCanvas.style.height = tileCanvas.height * parseInt(tileZoom.value,10) + 'px';
+    playerCanvas.style.width = playerCanvas.width * parseInt(playerZoom.value,10) + 'px';
+    playerCanvas.style.height = playerCanvas.height * parseInt(playerZoom.value,10) + 'px';
   }
-
   enemyZoom.addEventListener('input', updateZoom);
   npcZoom.addEventListener('input', updateZoom);
   bossZoom.addEventListener('input', updateZoom);
   tileZoom.addEventListener('input', updateZoom);
-
-  document.getElementById('enemyPlay').addEventListener('click', () => { enemyAnim = !enemyAnim; startAnim(); });
-  document.getElementById('npcPlay').addEventListener('click', () => { npcAnim = !npcAnim; startAnim(); });
+  playerZoom.addEventListener('input', updateZoom);
 
   function startAnim() {
     if (rafId) return;
     const step = () => {
       animTick++;
-      if (enemyAnim) updatePreview(enemyPreview, Math.floor(animTick/10));
-      if (npcAnim) updatePreview(npcPreview, Math.floor(animTick/12));
-      if (!enemyAnim && !npcAnim) { rafId = null; return; }
+      updatePreview(enemyPreview, Math.floor(animTick/20));
+      updatePreview(npcPreview, Math.floor(animTick/20));
       rafId = requestAnimationFrame(step);
     };
     rafId = requestAnimationFrame(step);
   }
 
   generateAll();
+  startAnim();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Changes
- Complete rewrite for cute dot-art style (2-2.5 head ratio, big eyes, pink cheeks)
- Colored outlines, 3-tone shading, checker dithering
- Added player (Mipurin) sprite: 4-dir walk + attack frames
- All 9 enemies, 8 NPCs, 3 bosses, 19 tiles with detailed pixel art
- Animation preview, zoom slider, usage guide maintained

## Categories
- Enemies: 9 types × 3 frames (32×32)
- NPCs: 8 types × 2 frames (32×32)  
- Bosses: 3 types × 4 frames (64×64)
- Tiles: 19 types (32×32)
- Player: 4 dir × walk/attack frames (32×32)

No game file changes.