### PR TITLE
Add rot-js CDN (jsdelivr) to fix ROT is not defined error

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@ canvas{
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/rot.js/2.2.0/rot.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tween.js/18.6.4/tween.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/rot-js@2/lib/rot.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
 <script src='js/game.js?v=1639'></script>
 <script src='js/ui/UIManager.js?v=1639'></script>


### PR DESCRIPTION
Add <script src="https://cdn.jsdelivr.net/npm/rot-js@2/lib/rot.js"> below tween.js in index.html to ensure ROT global is available for js/data_room.js.

https://claude.ai/code/session_01SZYhogr4jhqqw8F8B6Eeon